### PR TITLE
Add protobufjson package

### DIFF
--- a/go.work
+++ b/go.work
@@ -4,4 +4,5 @@ use (
 	./httperror
 	./logging
 	./otelutils
+	./protobufjson
 )

--- a/protobufjson/README.md
+++ b/protobufjson/README.md
@@ -1,0 +1,37 @@
+# protobufjson
+
+Implements the NATS Encoder interface, allowing NATS to automatically encode/decode messages with `protojson` through the use of an encoded connection.
+
+## Examples
+
+```go
+func main() {
+...
+	flag.Parse()
+	
+	nats.RegisterEncoder("protojson", &protobufjson.Codec{})
+
+...
+
+	nc, err := nats.Connect(
+		*natsURL,
+		nats.UserCredentials(*credsPath),
+		nats.RootCAs(*caCert),
+		nats.ClientCert(*tlsCert, *tlsKey),
+		nats.RetryOnFailedConnect(true),
+		nats.MaxReconnects(*maxReconnects),
+		nats.ReconnectWait(time.Duration(*reconnectWait)*time.Second),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	conn, err := nats.NewEncodedConn(nc, "protojson")
+	if err != nil {
+		log.Fatal(err)
+	}
+...
+
+```
+
+At that point NATS messages to/from that service are automatically encoded/decoded with protojson.

--- a/protobufjson/go.mod
+++ b/protobufjson/go.mod
@@ -1,0 +1,5 @@
+module github.com/cyverse-de/go-mod/protobufjson
+
+go 1.18
+
+require google.golang.org/protobuf v1.28.0

--- a/protobufjson/go.sum
+++ b/protobufjson/go.sum
@@ -1,0 +1,8 @@
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
+google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=

--- a/protobufjson/protobufjson.go
+++ b/protobufjson/protobufjson.go
@@ -1,0 +1,39 @@
+package protobufjson
+
+import (
+	"errors"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+// Codec is a an implmentation of the NATS Encoder interface that
+// can serialize/deserialize messages using protojson. Some logic is borrowed
+// from the protocol buffer encoder included in NATS.
+// See https://github.com/nats-io/nats.go/blob/main/encoders/protobuf/protobuf_enc.go
+type Codec struct{}
+
+func (c *Codec) Encode(subject string, v interface{}) ([]byte, error) {
+	msg, ok := v.(proto.Message)
+	if !ok {
+		return nil, errors.New("invalid protocol buffer message passed to Encode()")
+	}
+	b, err := protojson.Marshal(msg)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func (c *Codec) Decode(subject string, data []byte, vPtr interface{}) error {
+	if _, ok := vPtr.(*interface{}); ok {
+		return nil
+	}
+
+	msg, ok := vPtr.(proto.Message)
+	if !ok {
+		return errors.New("invalid protocol buffer message passed to Decode()")
+	}
+
+	return protojson.Unmarshal(data, msg)
+}


### PR DESCRIPTION
Adds the protobufjson package, which contains an implementation of the NATS Encoder interface, allowing it to be used with an EncodedConnection.