### PR TITLE
Add the header and svcerror modules, remove go.work files

### DIFF
--- a/header/go.mod
+++ b/header/go.mod
@@ -1,0 +1,3 @@
+module github.com/cyverse-de/go-mod/header
+
+go 1.24.2

--- a/header/header.go
+++ b/header/header.go
@@ -1,0 +1,25 @@
+// Deprecated: Provided for compatibility with code that used to use protocol buffers.
+
+package header
+
+type Header struct {
+	Map map[string]*Header_Value `json:"map,omitempty"`
+}
+
+func (x *Header) GetMap() map[string]*Header_Value {
+	if x != nil {
+		return x.Map
+	}
+	return nil
+}
+
+type Header_Value struct {
+	Value []string `json:"value,omitempty"`
+}
+
+func (x *Header_Value) GetValue() []string {
+	if x != nil {
+		return x.Value
+	}
+	return nil
+}

--- a/pbinit/go.mod
+++ b/pbinit/go.mod
@@ -2,6 +2,8 @@ module github.com/cyverse-de/go-mod/pbinit
 
 go 1.23.3
 
+replace github.com/cyverse-de/go-mod/gotelnats => ../gotelnats
+
 require (
 	github.com/cyverse-de/go-mod/gotelnats v0.0.15
 	github.com/cyverse-de/p/go/analysis v0.0.16
@@ -20,7 +22,7 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/klauspost/compress v1.17.8 // indirect
-	github.com/nats-io/nats.go v1.34.1 // indirect
+	github.com/nats-io/nats.go v1.37.0 // indirect
 	github.com/nats-io/nkeys v0.4.7 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	go.opentelemetry.io/otel v1.26.0 // indirect

--- a/pbinit/go.sum
+++ b/pbinit/go.sum
@@ -1,5 +1,3 @@
-github.com/cyverse-de/go-mod/gotelnats v0.0.12 h1:oq24rRC2Tsc2z/5d0cso9QqrSRq6ce+e0vfHlk+wtPA=
-github.com/cyverse-de/go-mod/gotelnats v0.0.12/go.mod h1:n9+Qw8jV5z+w476xk3RRPBQzJQbA/fehv4UiXtL+Zqk=
 github.com/cyverse-de/p v0.0.0-20240228001927-426a6bd80191 h1:f0tJEoxQ9t5X9JhH6P160uQt+j1K0LqAwOS7Uy5qzgQ=
 github.com/cyverse-de/p v0.0.0-20240228001927-426a6bd80191/go.mod h1:JM04cBlOajBkOVfQOEbBD6QwmWyupji9J84wfUA+LTc=
 github.com/cyverse-de/p/go/analysis v0.0.16 h1:E+SE/v3RE1znwnIzk4ugXiM0knVsBnTLmuv4fcvietc=
@@ -29,8 +27,8 @@ github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/klauspost/compress v1.17.8 h1:YcnTYrq7MikUT7k0Yb5eceMmALQPYBW/Xltxn0NAMnU=
 github.com/klauspost/compress v1.17.8/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
-github.com/nats-io/nats.go v1.34.1 h1:syWey5xaNHZgicYBemv0nohUPPmaLteiBEUT6Q5+F/4=
-github.com/nats-io/nats.go v1.34.1/go.mod h1:Ubdu4Nh9exXdSz0RVWRFBbRfrbSxOYd26oF0wkWclB8=
+github.com/nats-io/nats.go v1.37.0 h1:07rauXbVnnJvv1gfIyghFEo6lUcYRY0WXc3x7x0vUxE=
+github.com/nats-io/nats.go v1.37.0/go.mod h1:Ubdu4Nh9exXdSz0RVWRFBbRfrbSxOYd26oF0wkWclB8=
 github.com/nats-io/nkeys v0.4.7 h1:RwNJbbIdYCoClSDNY7QVKZlyb/wfT6ugvFCiKy6vDvI=
 github.com/nats-io/nkeys v0.4.7/go.mod h1:kqXRgRDPlGy7nGaEDMuYzmiJCIAAWDK0IMBtDmGD0nc=
 github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=

--- a/svcerror/go.mod
+++ b/svcerror/go.mod
@@ -1,0 +1,3 @@
+module github.com/cyverse-de/go-mod/svcerror
+
+go 1.23.3

--- a/svcerror/svcerror.go
+++ b/svcerror/svcerror.go
@@ -1,0 +1,116 @@
+// Deprecated: Provided for compatibility with code that used to use protocol buffers.
+
+package svcerror
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+)
+
+// *
+// The types of errors that can be retuned by message handlers.
+type ErrorCode int32
+
+const (
+	ErrorCode_UNSET             ErrorCode = 0  // Default value for the error code. Don't set the error code to this. Use Unspecified if tempted.
+	ErrorCode_UNSPECIFIED       ErrorCode = 1  // An error occurred, but the kind wasn't specified or included in the list.
+	ErrorCode_INTERNAL          ErrorCode = 2  // Internal error.
+	ErrorCode_NOT_FOUND         ErrorCode = 3  // The requested resource wasn't found.
+	ErrorCode_BAD_REQUEST       ErrorCode = 4  // The request was bad/wrong is some way.
+	ErrorCode_MARSHAL_FAILURE   ErrorCode = 5  // A failure to marshal a response.
+	ErrorCode_UNMARSHAL_FAILURE ErrorCode = 6  // A failure to unmarshal a request.
+	ErrorCode_PARAMETER_MISSING ErrorCode = 7  // A parameter is missing.
+	ErrorCode_PARAMETER_INVALID ErrorCode = 8  /// A parameter is invalid.
+	ErrorCode_UNAUTHENTICATED   ErrorCode = 9  /// Operation requires authentication, which was not provided.
+	ErrorCode_FORBIDDEN         ErrorCode = 10 /// Operation is no allowed.
+	ErrorCode_TIMEOUT           ErrorCode = 11 /// Operation timed out.
+	ErrorCode_UNSUPPORTED       ErrorCode = 12 /// Operation is not supported.
+	ErrorCode_UNIMPLEMENTED     ErrorCode = 13 /// Operation has not been implemented.
+)
+
+// Enum value maps for ErrorCode.
+var (
+	ErrorCode_name = map[int32]string{
+		0:  "UNSET",
+		1:  "UNSPECIFIED",
+		2:  "INTERNAL",
+		3:  "NOT_FOUND",
+		4:  "BAD_REQUEST",
+		5:  "MARSHAL_FAILURE",
+		6:  "UNMARSHAL_FAILURE",
+		7:  "PARAMETER_MISSING",
+		8:  "PARAMETER_INVALID",
+		9:  "UNAUTHENTICATED",
+		10: "FORBIDDEN",
+		11: "TIMEOUT",
+		12: "UNSUPPORTED",
+		13: "UNIMPLEMENTED",
+	}
+	ErrorCode_value = map[string]int32{
+		"UNSET":             0,
+		"UNSPECIFIED":       1,
+		"INTERNAL":          2,
+		"NOT_FOUND":         3,
+		"BAD_REQUEST":       4,
+		"MARSHAL_FAILURE":   5,
+		"UNMARSHAL_FAILURE": 6,
+		"PARAMETER_MISSING": 7,
+		"PARAMETER_INVALID": 8,
+		"UNAUTHENTICATED":   9,
+		"FORBIDDEN":         10,
+		"TIMEOUT":           11,
+		"UNSUPPORTED":       12,
+		"UNIMPLEMENTED":     13,
+	}
+)
+
+func (x ErrorCode) Enum() *ErrorCode {
+	p := new(ErrorCode)
+	*p = x
+	return p
+}
+
+func (x ErrorCode) String() string {
+	v := int32(x)
+	if slices.Contains(slices.Collect(maps.Keys(ErrorCode_name)), v) {
+		return ErrorCode_name[v]
+	}
+	return fmt.Sprintf("ErrorCode(%d)", v)
+}
+
+func (x ErrorCode) Value() int32 {
+	return int32(x)
+}
+
+// *
+// An error returned by a request handler.
+type ServiceError struct {
+	// The numeric error code from the error code enum.
+	ErrorCode ErrorCode `json:"error_code,omitempty"`
+	// The status code for the error.
+	StatusCode int32 `json:"status_code,omitempty"`
+	// The error's message.
+	Message string `json:"message,omitempty"`
+}
+
+func (x *ServiceError) GetErrorCode() ErrorCode {
+	if x != nil {
+		return x.ErrorCode
+	}
+	return ErrorCode_UNSET
+}
+
+func (x *ServiceError) GetStatusCode() int32 {
+	if x != nil {
+		return x.StatusCode
+	}
+	return 0
+}
+
+func (x *ServiceError) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}


### PR DESCRIPTION
As part of the effort towards simplifying backend development and deployment, we're removing our dependency on protocol buffers. This PR adds simplified versions of the svcerror and header modules available at github.com/cyverse-de/p/go/svcerror and github.com/cyverse-de/p/go/header. 

Additionally, it removes the go.work file, which probably shouldn't have been under version control to begin with.