### PR TITLE
Add viceauth module for signed OAuth state

### DIFF
--- a/viceauth/go.mod
+++ b/viceauth/go.mod
@@ -1,0 +1,3 @@
+module github.com/cyverse-de/go-mod/viceauth
+
+go 1.25

--- a/viceauth/viceauth.go
+++ b/viceauth/viceauth.go
@@ -1,0 +1,95 @@
+// Package viceauth provides a signed-state codec for the VICE OAuth login
+// flow. The OAuth "state" parameter must round-trip from vice-proxy through
+// Keycloak and a vice-operator relay, so it carries both a CSRF token and the
+// original app URL the browser should be returned to. An HMAC-SHA256 signature
+// lets the operator trust the embedded URL without sharing vice-proxy's OIDC
+// client secret.
+package viceauth
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+)
+
+// StateClaims is the payload carried in the OAuth state parameter.
+type StateClaims struct {
+	// StateID is the CSRF token. vice-proxy stores it in its state-session
+	// cookie and compares it against this value on the callback.
+	StateID string `json:"sid"`
+
+	// Origin is the full app URL (scheme, host, path, query) the browser
+	// should be returned to once the operator relays the authorization code
+	// back. Consumers MUST validate the host against an allowlist before
+	// redirecting to it — a valid signature only proves the value was not
+	// tampered with, not that the target is safe.
+	Origin string `json:"origin"`
+}
+
+// Codec encodes and decodes signed OAuth state values. Construct one per
+// process with NewCodec and reuse it; it is safe for concurrent use.
+type Codec struct {
+	secret []byte
+}
+
+// NewCodec returns a Codec that signs and verifies state values with the given
+// HMAC secret. The same secret must be configured on every component that
+// encodes or decodes state (vice-proxy and each vice-operator).
+func NewCodec(secret []byte) *Codec {
+	return &Codec{secret: secret}
+}
+
+// Errors returned by Decode. Callers should treat any error as "untrusted
+// state" and refuse to act on it, rather than distinguishing between them.
+var (
+	ErrMalformedState = errors.New("viceauth: malformed state")
+	ErrBadSignature   = errors.New("viceauth: state signature mismatch")
+)
+
+// Encode serializes claims to JSON and returns a signed, URL-safe state value
+// of the form "<base64url(payload)>.<base64url(signature)>".
+func (c *Codec) Encode(claims StateClaims) (string, error) {
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+	b64 := base64.RawURLEncoding.EncodeToString(payload)
+	return b64 + "." + c.sign(b64), nil
+}
+
+// Decode verifies the signature on a state value produced by Encode and
+// returns the embedded claims. It returns ErrMalformedState for structurally
+// invalid input and ErrBadSignature when the signature does not match; in
+// either case the state must not be trusted.
+func (c *Codec) Decode(state string) (StateClaims, error) {
+	var claims StateClaims
+
+	b64, sig, ok := strings.Cut(state, ".")
+	if !ok {
+		return claims, ErrMalformedState
+	}
+
+	// Constant-time comparison guards against signature-timing attacks.
+	if !hmac.Equal([]byte(c.sign(b64)), []byte(sig)) {
+		return claims, ErrBadSignature
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(b64)
+	if err != nil {
+		return claims, ErrMalformedState
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return claims, ErrMalformedState
+	}
+	return claims, nil
+}
+
+// sign returns the base64url-encoded HMAC-SHA256 of msg.
+func (c *Codec) sign(msg string) string {
+	mac := hmac.New(sha256.New, c.secret)
+	mac.Write([]byte(msg))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}

--- a/viceauth/viceauth_test.go
+++ b/viceauth/viceauth_test.go
@@ -1,0 +1,71 @@
+package viceauth
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestCodecRoundTrip(t *testing.T) {
+	c := NewCodec([]byte("test-secret"))
+
+	cases := []StateClaims{
+		{StateID: "81d5cc3f-4fa8-11f1-a186-1a46dc0baeb8", Origin: "https://a44abe2d0.cyverse.run:4343/foo?bar=baz"},
+		{StateID: "sid-only", Origin: ""},
+		{StateID: "", Origin: ""},
+	}
+	for _, want := range cases {
+		state, err := c.Encode(want)
+		if err != nil {
+			t.Fatalf("Encode(%+v): %v", want, err)
+		}
+		got, err := c.Decode(state)
+		if err != nil {
+			t.Fatalf("Decode(%q): %v", state, err)
+		}
+		if got != want {
+			t.Errorf("round trip mismatch: got %+v, want %+v", got, want)
+		}
+	}
+}
+
+func TestDecodeRejectsUntrustedState(t *testing.T) {
+	c := NewCodec([]byte("test-secret"))
+
+	valid, err := c.Encode(StateClaims{StateID: "sid", Origin: "https://x.cyverse.run:4343/"})
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	payload, sig, _ := strings.Cut(valid, ".")
+
+	otherSecret, err := NewCodec([]byte("other-secret")).Encode(StateClaims{StateID: "sid"})
+	if err != nil {
+		t.Fatalf("Encode with other secret: %v", err)
+	}
+
+	// A validly-signed value whose payload is not base64 — exercises the
+	// decode path past the signature check.
+	badPayload := "!!!not-base64!!!"
+	signedBadPayload := badPayload + "." + c.sign(badPayload)
+
+	tests := []struct {
+		name    string
+		state   string
+		wantErr error
+	}{
+		{"empty", "", ErrMalformedState},
+		{"no signature delimiter", payload, ErrMalformedState},
+		{"tampered payload", payload + "x." + sig, ErrBadSignature},
+		{"tampered signature", payload + "." + sig + "x", ErrBadSignature},
+		{"signed with a different secret", otherSecret, ErrBadSignature},
+		{"valid signature, non-base64 payload", signedBadPayload, ErrMalformedState},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := c.Decode(tt.state)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("Decode(%q) = %v, want %v", tt.state, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- New `viceauth` micro-library: an HMAC-SHA256 signed-state codec for the VICE OAuth login flow.
- The OAuth `state` parameter must round-trip from `vice-proxy` → Keycloak → a `vice-operator` relay → back to the app subdomain. It carries both a CSRF token (`StateID`) and the original app URL (`Origin`).
- The signature lets the operator trust the embedded `Origin` without sharing `vice-proxy`'s OIDC client secret.

## Context
Keycloak only honors `*` as a trailing wildcard in Valid Redirect URIs, so per-app VICE subdomains (`https://<random>.cyverse.run:4343/`) can't be matched by `https://*.cyverse.run:4343/*`. The fix routes the OAuth callback through a fixed per-operator URL that relays the code back to the app; this module is the shared state codec that makes the relay trustworthy.

Consumed by companion PRs in `vice-proxy` and `app-exposer` (vice-operator).

## Test plan
- [x] `go test ./...` in `viceauth/` — table-driven round-trip + untrusted-state rejection
- [x] `go vet ./...`, `gofmt`
- [ ] Tag `viceauth/v1.0.0` once merged so consumers can pin a release

🤖 Generated with [Claude Code](https://claude.com/claude-code)